### PR TITLE
Add help command

### DIFF
--- a/cb.py
+++ b/cb.py
@@ -466,7 +466,7 @@ class CoopBoop:
             return
 
         command = cmd[1]
-        if method not in self.perms.keys():
+        if command not in self.perms.keys():
             await self.fmt_reply(event, f"Command {command} does not exist!")
             return
         

--- a/cb.py
+++ b/cb.py
@@ -164,7 +164,7 @@ class CoopBoop:
             pattern = event_handler[1].pattern
             if pattern is not None:
                 method = event_handler[0]
-                pattern = pattern.__self__.pattern
+                pattern = pattern.__self__.pattern[1:]
                 mapping[pattern] = method
         return mapping
 

--- a/cb.py
+++ b/cb.py
@@ -471,7 +471,7 @@ class CoopBoop:
             return
 
         method = getattr(self, command)
-        print(method.__docstring__)
+        print(method.__doc__)
         #for prop in dir(self):
         #    try:
         #        method = getattr(self, prop)

--- a/cb.py
+++ b/cb.py
@@ -459,7 +459,7 @@ class CoopBoop:
 
     @perm
     async def help(self, event):
-            self.client.add_event_handler(self.exif, events.NewMessage(pattern=';exif'))
+        self.client.add_event_handler(self.exif, events.NewMessage(pattern=';exif'))
 
         if len(cmd) != 2:
             await self.fmt_reply(event, "Improper syntax for help!")

--- a/cb.py
+++ b/cb.py
@@ -474,7 +474,10 @@ class CoopBoop:
         mapping = await self.map_pattern_to_event_method()
 
         if len(cmd) == 1:
-            pass
+            command_list = "**Commands:**"
+            for command in mapping.keys():
+                message += f"- ;{command}\n"
+            self.fmt_reply(event, command_list)
         elif len(cmd) == 2:
             command = cmd[1]
             if command not in self.perms.keys():

--- a/cb.py
+++ b/cb.py
@@ -161,8 +161,8 @@ class CoopBoop:
     async def map_pattern_to_event_method(self):
         mapping = {}
         for event_handler in self.client.list_event_handlers():
-            mapping[event_handler[1].pattern()] = event_handler[0]
-            print(event_handler[1].pattern())
+            mapping[event_handler[1].pattern] = event_handler[0]
+            print(event_handler[1].pattern)
         return mapping
 
     @perm

--- a/cb.py
+++ b/cb.py
@@ -16,8 +16,7 @@ from telethon import TelegramClient, events, tl, errors
 logging.basicConfig(level=logging.INFO)
 
 class CoopBoop:
-    """
-    Driver class for the userbot
+    """ Driver class for the userbot
     """
 
     # pylint: disable=too-many-instance-attributes
@@ -474,6 +473,9 @@ class CoopBoop:
 
         method = getattr(getattr(self, command), "__wrapped__")
         await self.fmt_reply(event, method.__doc__)
+
+        for task in asyncio.Task.all_tasks():
+            print(task)
 
     async def literally_everything(self, event):
         """ Displays every single event the bot encounters for debugging or brainstorming

--- a/cb.py
+++ b/cb.py
@@ -422,7 +422,7 @@ class CoopBoop:
         cmd = event.message.raw_text.split(' ')
 
         if len(cmd) != 2:
-            await self.fmt_reply(event, "Improper syntax for exif!")
+            await self.fmt_reply(event, "improper syntax for exif!")
         elif event.message.media is None:
             await self.fmt_reply(event, "No image given!")
         elif not isinstance(event.message.media, tl.types.MessageMediaDocument):
@@ -457,6 +457,28 @@ class CoopBoop:
             else:
                 await self.fmt_reply(event, "Improper syntax for exif!")
 
+    @perm
+    async def help(self, event):
+            self.client.add_event_handler(self.exif, events.NewMessage(pattern=';exif'))
+
+        if len(cmd) != 2:
+            await self.fmt_reply(event, "Improper syntax for help!")
+            return
+
+        command = cmd[1]
+        if method not in self.perms.keys():
+            await self.fmt_reply(event, f"Command {command} does not exist!")
+            return
+        
+        #for prop in dir(self):
+        #    try:
+        #        method = getattr(self, prop)
+        #        if not isinstance(val, types.MethodType):
+        #                exif_dat1a[prop] = val
+        #    except Exception:
+        #        pass
+
+
     async def literally_everything(self, event):
         """ Displays every single event the bot encounters for debugging or brainstorming
         -Should not be set by default, commented out below
@@ -484,6 +506,7 @@ class CoopBoop:
             self.client.add_event_handler(self.do_not_disturb_responder, \
                                           events.NewMessage(incoming=True))
             self.client.add_event_handler(self.exif, events.NewMessage(pattern=';exif'))
+            self.client.add_event_handler(self.exif, events.NewMessage(pattern=';help'))
             #self.client.add_event_handler(self.literally_everything)
             print("Events added")
 

--- a/cb.py
+++ b/cb.py
@@ -158,11 +158,10 @@ class CoopBoop:
                 return exif_data
             return None
 
-    async def map_event_to_pattern(self):
+    async def map_pattern_to_event_method(self):
         mapping = {}
         for event_handler in self.client.list_event_handlers():
             mapping[event_handler[0]] = event_handler[1].pattern
-            print(dir(event_handler[1].pattern))
         return mapping
 
     @perm
@@ -478,7 +477,7 @@ class CoopBoop:
             await self.fmt_reply(event, f"Command {command} does not exist!")
             return
 
-        mapping = await self.map_event_to_pattern()
+        mapping = await self.map_pattern_to_event_method()
         print(mapping.items())
 
     async def literally_everything(self, event):

--- a/cb.py
+++ b/cb.py
@@ -471,15 +471,8 @@ class CoopBoop:
             return
 
         method = getattr(self, command)
-        print(method.__doc__)
-        #for prop in dir(self):
-        #    try:
-        #        method = getattr(self, prop)
-        #        if not isinstance(val, types.MethodType):
-        #                exif_dat1a[prop] = val
-        #    except Exception:
-        #        pass
-
+        print(f"method: {method}")
+        print(f"method.__doc__: {method.__doc__}")
 
     async def literally_everything(self, event):
         """ Displays every single event the bot encounters for debugging or brainstorming

--- a/cb.py
+++ b/cb.py
@@ -162,6 +162,7 @@ class CoopBoop:
         mapping = {}
         for event_handler in self.client.list_event_handlers():
             mapping[event_handler[0]] = event_handler[1].pattern
+            print(dir(event_handler[1].patter))
         return mapping
 
     @perm

--- a/cb.py
+++ b/cb.py
@@ -162,8 +162,7 @@ class CoopBoop:
         mapping = {}
         for event_handler in self.client.list_event_handlers():
             mapping[event_handler[1].pattern] = event_handler[0]
-            print(f"just RE: {event_handler[1]}, {type(event_handler[1])}")
-            print(f"pattern: {event_handler[1].pattern}")
+            print(f"dir(pattern): {dir(event_handler[1].pattern)}")
         return mapping
 
     @perm

--- a/cb.py
+++ b/cb.py
@@ -10,6 +10,7 @@ import types
 import logging
 import os
 import exif
+import functools
 from telethon import TelegramClient, events, tl, errors
 
 logging.basicConfig(level=logging.INFO)
@@ -62,6 +63,7 @@ class CoopBoop:
         # pylint: disable=no-self-argument
         # pylint: disable=not-callable
         # pylint: disable=no-member
+        @functools.wraps(wrapped_handler)
         async def handler(self, event):
             auth = self.perms[wrapped_handler.__name__]['whitelist']
             xauth = self.perms[wrapped_handler.__name__]['blacklist']

--- a/cb.py
+++ b/cb.py
@@ -473,9 +473,7 @@ class CoopBoop:
             return
 
         method = getattr(getattr(self, command), "__wrapped__")
-        print(f"method: {method}")
-        print(f"dir(method): {dir(method)}")
-
+        await self.fmt_reply(event, help(method))
 
     async def literally_everything(self, event):
         """ Displays every single event the bot encounters for debugging or brainstorming

--- a/cb.py
+++ b/cb.py
@@ -480,6 +480,8 @@ class CoopBoop:
             await self.fmt_reply(event, command_list)
         elif len(cmd) == 2:
             command = cmd[1]
+            if ';' in command:
+                command = command[1:]
             if command not in self.perms.keys():
                 await self.fmt_reply(event, f"Command {command} does not exist!")
             else:

--- a/cb.py
+++ b/cb.py
@@ -470,8 +470,8 @@ class CoopBoop:
             await self.fmt_reply(event, f"Command {command} does not exist!")
             return
 
-        print(dir(self))
-        
+        method = getattr(self, command)
+        print(method.__docstring__)
         #for prop in dir(self):
         #    try:
         #        method = getattr(self, prop)

--- a/cb.py
+++ b/cb.py
@@ -162,7 +162,7 @@ class CoopBoop:
         mapping = {}
         for event_handler in self.client.list_event_handlers():
             mapping[event_handler[0]] = event_handler[1].pattern
-            print(dir(event_handler[1].patter))
+            print(dir(event_handler[1].pattern))
         return mapping
 
     @perm

--- a/cb.py
+++ b/cb.py
@@ -163,7 +163,7 @@ class CoopBoop:
         for event_handler in self.client.list_event_handlers():
             mapping[event_handler[1].pattern] = event_handler[0]
             print(type(event_handler[1].pattern))
-            print(type(event_handler[1].pattern))
+            print(dir(event_handler[1].pattern))
             print(event_handler[1].pattern)
         return mapping
 

--- a/cb.py
+++ b/cb.py
@@ -161,11 +161,14 @@ class CoopBoop:
     async def map_pattern_to_event_method(self):
         mapping = {}
         for event_handler in self.client.list_event_handlers():
-            mapping[event_handler[1].pattern] = event_handler[0]
-            print(f"pattern: {event_handler[1].pattern}")
-            print(f"dir(pattern): {dir(event_handler[1].pattern)}")
-            print(f"type(pattern): {type(event_handler[1].pattern)}")
-            print(f"The big trick: {event_handler[1].pattern.__self__.pattern}")
+            pattern = event_handler[1].pattern
+            method = event_handler[0]
+            if pattern:
+                mapping[pattern] = method
+                print(f"pattern: {event_handler[1].pattern}")
+                print(f"dir(pattern): {dir(event_handler[1].pattern)}")
+                print(f"type(pattern): {type(event_handler[1].pattern)}")
+                print(f"The big trick: {event_handler[1].pattern.__self__.pattern}")
         return mapping
 
     @perm

--- a/cb.py
+++ b/cb.py
@@ -475,9 +475,10 @@ class CoopBoop:
         await self.fmt_reply(event, method.__doc__)
 
         for event in self.client.list_event_handlers():
-            print(event)
-            print(type(event))
-            print(dir(event))
+            for thing in event:
+                print(thing)
+                print(type(thing))
+                print(dir(thing))
 
     async def literally_everything(self, event):
         """ Displays every single event the bot encounters for debugging or brainstorming

--- a/cb.py
+++ b/cb.py
@@ -161,9 +161,7 @@ class CoopBoop:
     async def map_event_to_pattern(self):
         mapping = {}
         for event_handler in self.client.list_event_handlers():
-            print(event_handler[0])
-            print(dir(event_handler[0]))
-            mapping[event_handler[0].__wrapped__] = event_handler[1].pattern
+            mapping[event_handler[0]] = event_handler[1].pattern
         return mapping
 
     @perm

--- a/cb.py
+++ b/cb.py
@@ -474,7 +474,7 @@ class CoopBoop:
         mapping = await self.map_pattern_to_event_method()
 
         if len(cmd) == 1:
-            command_list = "**Commands:**"
+            command_list = "**Commands:**\n"
             for command in mapping.keys():
                 command_list += f"- ;{command}\n"
             await self.fmt_reply(event, command_list)

--- a/cb.py
+++ b/cb.py
@@ -162,7 +162,8 @@ class CoopBoop:
         mapping = {}
         for event_handler in self.client.list_event_handlers():
             mapping[event_handler[1].pattern] = event_handler[0]
-            print(event_handler[1].pattern)
+            print(f"just RE: {event_handler[1]}, {type(event_handler[1])}")
+            print(f"pattern: {event_handler[1].pattern}")
         return mapping
 
     @perm

--- a/cb.py
+++ b/cb.py
@@ -477,7 +477,7 @@ class CoopBoop:
             await self.fmt_reply(event, f"Command {command} does not exist!")
             return
 
-        mapping = await map_event_to_pattern()
+        mapping = await self.map_event_to_pattern()
         print(mapping.items())
 
     async def literally_everything(self, event):

--- a/cb.py
+++ b/cb.py
@@ -158,6 +158,12 @@ class CoopBoop:
                 return exif_data
             return None
 
+    async def map_event_to_pattern(self):
+        mapping = {}
+        for event_handler in self.client.list_event_handlers():
+            mapping[event_handler[0].__wrapped__] = event_handler[1].pattern
+        return mapping
+
     @perm
     async def set_header(self, event):
         """ Set the header of the bot at self.header to all text after ";hdr "
@@ -471,14 +477,8 @@ class CoopBoop:
             await self.fmt_reply(event, f"Command {command} does not exist!")
             return
 
-        method = getattr(getattr(self, command), "__wrapped__")
-        await self.fmt_reply(event, method.__doc__)
-
-        for event in self.client.list_event_handlers():
-            for thing in event:
-                print(thing)
-                print(type(thing))
-                print(dir(thing))
+        mapping = await map_event_to_pattern()
+        print(mapping.items())
 
     async def literally_everything(self, event):
         """ Displays every single event the bot encounters for debugging or brainstorming

--- a/cb.py
+++ b/cb.py
@@ -162,6 +162,7 @@ class CoopBoop:
         mapping = {}
         for event_handler in self.client.list_event_handlers():
             mapping[event_handler[1].pattern] = event_handler[0]
+            print(f"pattern: {event_handler[1].pattern}")
             print(f"dir(pattern): {dir(event_handler[1].pattern)}")
             print(f"type(pattern): {type(event_handler[1].pattern)}")
         return mapping

--- a/cb.py
+++ b/cb.py
@@ -482,7 +482,7 @@ class CoopBoop:
             command = cmd[1]
             if ';' in command:
                 command = command[1:]
-            if command not in self.perms.keys():
+            if command not in mapping.keys():
                 await self.fmt_reply(event, f"Command {command} does not exist!")
             else:
                 await self.fmt_reply(event, f"{mapping[command].__doc__}")

--- a/cb.py
+++ b/cb.py
@@ -477,7 +477,7 @@ class CoopBoop:
             command_list = "**Commands:**"
             for command in mapping.keys():
                 command_list += f"- ;{command}\n"
-            self.fmt_reply(event, command_list)
+            await self.fmt_reply(event, command_list)
         elif len(cmd) == 2:
             command = cmd[1]
             if command not in self.perms.keys():

--- a/cb.py
+++ b/cb.py
@@ -459,7 +459,7 @@ class CoopBoop:
 
     @perm
     async def help(self, event):
-        self.client.add_event_handler(self.exif, events.NewMessage(pattern=';exif'))
+        cmd = event.message.raw_text.split(' ')
 
         if len(cmd) != 2:
             await self.fmt_reply(event, "Improper syntax for help!")

--- a/cb.py
+++ b/cb.py
@@ -161,8 +161,10 @@ class CoopBoop:
     async def map_pattern_to_event_method(self):
         mapping = {}
         for event_handler in self.client.list_event_handlers():
-            mapping[event_handler[0]] = event_handler[1].pattern
+            mapping[event_handler[1].pattern] = event_handler[0]
             print(type(event_handler[1].pattern))
+            print(type(event_handler[1].pattern))
+            print(event_handler[1].pattern)
         return mapping
 
     @perm

--- a/cb.py
+++ b/cb.py
@@ -469,6 +469,8 @@ class CoopBoop:
         if command not in self.perms.keys():
             await self.fmt_reply(event, f"Command {command} does not exist!")
             return
+
+        print(dir(self))
         
         #for prop in dir(self):
         #    try:

--- a/cb.py
+++ b/cb.py
@@ -506,7 +506,7 @@ class CoopBoop:
             self.client.add_event_handler(self.do_not_disturb_responder, \
                                           events.NewMessage(incoming=True))
             self.client.add_event_handler(self.exif, events.NewMessage(pattern=';exif'))
-            self.client.add_event_handler(self.exif, events.NewMessage(pattern=';help'))
+            self.client.add_event_handler(self.help, events.NewMessage(pattern=';help'))
             #self.client.add_event_handler(self.literally_everything)
             print("Events added")
 

--- a/cb.py
+++ b/cb.py
@@ -482,11 +482,7 @@ class CoopBoop:
             else:
                 await self.fmt_reply(event, f"{mapping[command].__doc__}")
         else:
-            await self.fmt_reply(event, "Improper syntax for help!")
-            return
-
-        print(mapping.items())
-        
+            await self.fmt_reply(event, "Improper syntax for help!") 
 
     async def literally_everything(self, event):
         """ Displays every single event the bot encounters for debugging or brainstorming

--- a/cb.py
+++ b/cb.py
@@ -163,6 +163,7 @@ class CoopBoop:
         for event_handler in self.client.list_event_handlers():
             mapping[event_handler[1].pattern] = event_handler[0]
             print(f"dir(pattern): {dir(event_handler[1].pattern)}")
+            print(f"type(pattern): {type(event_handler[1].pattern)}")
         return mapping
 
     @perm

--- a/cb.py
+++ b/cb.py
@@ -287,7 +287,8 @@ class CoopBoop:
 
     @perm
     async def activity(self, event):
-        """ Return a list of the top 10 most active/inactive members since time provided (if any)
+        """
+        Return a list of the top 10 most active/inactive members since time provided (if any)
         -Format: ;activity choice date(optional) chatID(optional) results_count(optional)
         -choice         --> active or inactive, can be shortened to a or i
         -date           --> time in format year-month-day or year-month-dayThour:minute:second,

--- a/cb.py
+++ b/cb.py
@@ -475,6 +475,7 @@ class CoopBoop:
         await self.fmt_reply(event, method.__doc__)
 
         for event in self.client.list_event_handlers():
+            print(event)
             print(dir(event))
 
     async def literally_everything(self, event):

--- a/cb.py
+++ b/cb.py
@@ -161,6 +161,8 @@ class CoopBoop:
     async def map_event_to_pattern(self):
         mapping = {}
         for event_handler in self.client.list_event_handlers():
+            print(event_handler[0])
+            print(dir(event_handler[0]))
             mapping[event_handler[0].__wrapped__] = event_handler[1].pattern
         return mapping
 

--- a/cb.py
+++ b/cb.py
@@ -476,7 +476,7 @@ class CoopBoop:
         if len(cmd) == 1:
             command_list = "**Commands:**"
             for command in mapping.keys():
-                message += f"- ;{command}\n"
+                command_list += f"- ;{command}\n"
             self.fmt_reply(event, command_list)
         elif len(cmd) == 2:
             command = cmd[1]

--- a/cb.py
+++ b/cb.py
@@ -161,7 +161,7 @@ class CoopBoop:
     async def map_pattern_to_event_method(self):
         mapping = {}
         for event_handler in self.client.list_event_handlers():
-            mapping[event_handler[0]] = event_handler[1].pattern
+            mapping[event_handler[0]] = event_handler[1].pattern.pattern
         return mapping
 
     @perm
@@ -479,6 +479,7 @@ class CoopBoop:
 
         mapping = await self.map_pattern_to_event_method()
         print(mapping.items())
+        
 
     async def literally_everything(self, event):
         """ Displays every single event the bot encounters for debugging or brainstorming

--- a/cb.py
+++ b/cb.py
@@ -161,10 +161,8 @@ class CoopBoop:
     async def map_pattern_to_event_method(self):
         mapping = {}
         for event_handler in self.client.list_event_handlers():
-            mapping[event_handler[1].pattern] = event_handler[0]
-            print(type(event_handler[1].pattern))
-            print(dir(event_handler[1].pattern))
-            print(event_handler[1].pattern)
+            mapping[event_handler[1].pattern()] = event_handler[0]
+            print(event_handler[1].pattern())
         return mapping
 
     @perm

--- a/cb.py
+++ b/cb.py
@@ -474,6 +474,8 @@ class CoopBoop:
     @perm
     async def help(self, event):
         """ Print out either the list of commands or the docstring for a provided command
+        -Format: ;help command_name(optional)
+
         -Ex:  ;help
               ;help exif
               ;help ;dnd

--- a/cb.py
+++ b/cb.py
@@ -162,13 +162,10 @@ class CoopBoop:
         mapping = {}
         for event_handler in self.client.list_event_handlers():
             pattern = event_handler[1].pattern
-            method = event_handler[0]
-            if pattern:
+            if pattern is not None:
+                method = event_handler[0]
+                pattern = pattern.__self__.pattern
                 mapping[pattern] = method
-                print(f"pattern: {event_handler[1].pattern}")
-                print(f"dir(pattern): {dir(event_handler[1].pattern)}")
-                print(f"type(pattern): {type(event_handler[1].pattern)}")
-                print(f"The big trick: {event_handler[1].pattern.__self__.pattern}")
         return mapping
 
     @perm
@@ -485,6 +482,7 @@ class CoopBoop:
             return
 
         mapping = await self.map_pattern_to_event_method()
+        print(mapping.items())
         
 
     async def literally_everything(self, event):

--- a/cb.py
+++ b/cb.py
@@ -473,7 +473,7 @@ class CoopBoop:
             return
 
         method = getattr(getattr(self, command), "__wrapped__")
-        await self.fmt_reply(event, help(method))
+        await self.fmt_reply(event, method.__doc__)
 
     async def literally_everything(self, event):
         """ Displays every single event the bot encounters for debugging or brainstorming

--- a/cb.py
+++ b/cb.py
@@ -287,8 +287,7 @@ class CoopBoop:
 
     @perm
     async def activity(self, event):
-        """
-        Return a list of the top 10 most active/inactive members since time provided (if any)
+        """ Return a list of the top 10 most active/inactive members since time provided (if any)
         -Format: ;activity choice date(optional) chatID(optional) results_count(optional)
         -choice         --> active or inactive, can be shortened to a or i
         -date           --> time in format year-month-day or year-month-dayThour:minute:second,

--- a/cb.py
+++ b/cb.py
@@ -472,7 +472,7 @@ class CoopBoop:
 
         method = getattr(self, command)
         print(f"method: {method}")
-        print(f"method.__doc__: {method.__doc__}")
+        print(f"dir(method): {dir(method)}")
 
     async def literally_everything(self, event):
         """ Displays every single event the bot encounters for debugging or brainstorming

--- a/cb.py
+++ b/cb.py
@@ -161,7 +161,8 @@ class CoopBoop:
     async def map_pattern_to_event_method(self):
         mapping = {}
         for event_handler in self.client.list_event_handlers():
-            mapping[event_handler[0]] = event_handler[1].pattern.pattern
+            mapping[event_handler[0]] = event_handler[1].pattern
+            print(type(event_handler[1].pattern))
         return mapping
 
     @perm
@@ -478,7 +479,6 @@ class CoopBoop:
             return
 
         mapping = await self.map_pattern_to_event_method()
-        print(mapping.items())
         
 
     async def literally_everything(self, event):

--- a/cb.py
+++ b/cb.py
@@ -471,17 +471,20 @@ class CoopBoop:
     @perm
     async def help(self, event):
         cmd = event.message.raw_text.split(' ')
+        mapping = await self.map_pattern_to_event_method()
 
-        if len(cmd) != 2:
+        if len(cmd) == 1:
+            pass
+        elif len(cmd) == 2:
+            command = cmd[1]
+            if command not in self.perms.keys():
+                await self.fmt_reply(event, f"Command {command} does not exist!")
+            else:
+                await self.fmt_reply(event, f"{mapping[command].__doc__}")
+        else:
             await self.fmt_reply(event, "Improper syntax for help!")
             return
 
-        command = cmd[1]
-        if command not in self.perms.keys():
-            await self.fmt_reply(event, f"Command {command} does not exist!")
-            return
-
-        mapping = await self.map_pattern_to_event_method()
         print(mapping.items())
         
 

--- a/cb.py
+++ b/cb.py
@@ -159,6 +159,9 @@ class CoopBoop:
             return None
 
     async def map_pattern_to_event_method(self):
+        """ Get dictionary mapping of commands to the methods they trigger
+        -Commands are specified by setting a pattern when registering an event
+        """
         mapping = {}
         for event_handler in self.client.list_event_handlers():
             pattern = event_handler[1].pattern
@@ -424,8 +427,8 @@ class CoopBoop:
     @perm
     async def exif(self, event):
         """ Remove or return the data from a JPEG/.jpg file.
-        -Format:    ;exif clean
-                    ;exif data
+        -Ex:  ;exif clean
+              ;exif data
         -Must provide thumbnailed/uncompressed JPEG/.jpg file (no support for TIFF yet)
         -Command must be the "description"/accompanying message of the uploaded image
         """
@@ -470,6 +473,12 @@ class CoopBoop:
 
     @perm
     async def help(self, event):
+        """ Print out either the list of commands or the docstring for a provided command
+        -Ex:  ;help
+              ;help exif
+              ;help ;dnd
+        """
+
         cmd = event.message.raw_text.split(' ')
         mapping = await self.map_pattern_to_event_method()
 

--- a/cb.py
+++ b/cb.py
@@ -475,7 +475,7 @@ class CoopBoop:
         await self.fmt_reply(event, method.__doc__)
 
         for event in self.client.list_event_handlers():
-            print(event)
+            print(dir(event))
 
     async def literally_everything(self, event):
         """ Displays every single event the bot encounters for debugging or brainstorming

--- a/cb.py
+++ b/cb.py
@@ -476,6 +476,7 @@ class CoopBoop:
 
         for event in self.client.list_event_handlers():
             print(event)
+            print(type(event))
             print(dir(event))
 
     async def literally_everything(self, event):

--- a/cb.py
+++ b/cb.py
@@ -165,6 +165,7 @@ class CoopBoop:
             print(f"pattern: {event_handler[1].pattern}")
             print(f"dir(pattern): {dir(event_handler[1].pattern)}")
             print(f"type(pattern): {type(event_handler[1].pattern)}")
+            print(f"The big trick: {event_handler[1].pattern.__self__.pattern}")
         return mapping
 
     @perm

--- a/cb.py
+++ b/cb.py
@@ -474,8 +474,8 @@ class CoopBoop:
         method = getattr(getattr(self, command), "__wrapped__")
         await self.fmt_reply(event, method.__doc__)
 
-        for task in asyncio.Task.all_tasks():
-            print(task)
+        for event in self.client.list_event_handlers():
+            print(event)
 
     async def literally_everything(self, event):
         """ Displays every single event the bot encounters for debugging or brainstorming

--- a/cb.py
+++ b/cb.py
@@ -472,9 +472,10 @@ class CoopBoop:
             await self.fmt_reply(event, f"Command {command} does not exist!")
             return
 
-        method = getattr(self, command)
+        method = getattr(getattr(self, command), "__wrapped__")
         print(f"method: {method}")
         print(f"dir(method): {dir(method)}")
+
 
     async def literally_everything(self, event):
         """ Displays every single event the bot encounters for debugging or brainstorming

--- a/cb.py
+++ b/cb.py
@@ -9,8 +9,8 @@ import json
 import types
 import logging
 import os
-import exif
 import functools
+import exif
 from telethon import TelegramClient, events, tl, errors
 
 logging.basicConfig(level=logging.INFO)
@@ -20,6 +20,7 @@ class CoopBoop:
     """
 
     # pylint: disable=too-many-instance-attributes
+    # pylint: disable=too-many-public-methods
     # pylint: disable=no-self-use
 
     def __init__(self):
@@ -498,7 +499,7 @@ class CoopBoop:
             else:
                 await self.fmt_reply(event, f"{mapping[command].__doc__}")
         else:
-            await self.fmt_reply(event, "Improper syntax for help!") 
+            await self.fmt_reply(event, "Improper syntax for help!")
 
     async def literally_everything(self, event):
         """ Displays every single event the bot encounters for debugging or brainstorming

--- a/config.json
+++ b/config.json
@@ -39,7 +39,10 @@
     "exif": {
       "whitelist": [ "OWNER" ],
       "blacklist": []
-    }
+    },
+    "help": {
+      "whitelist": [ "OWNER" ],
+      "blacklist": []
   },
   "header": "`CoopBoop`",
   "dnd_msg": "None",


### PR DESCRIPTION
-Add functools
-Add functools wrapper for perm decorator so that you can get the original function when getting the attribute with the matching method name from the object or self
-Add method which returns the mapping of the command (pattern) to the corresponding method (method called when pattern met)
-Add help function which prints out commands with no arguments, or the docstring for a command when a command is provided