### PR TITLE
Config saving

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Currently, you must update it manually. Generally, it's best to stick with self.
 
 You can `tail -f bot_log.txt` to watch bot run in real time
 
+For the function save_config, never pass user input as the arg. This could result in arbitrary file overwrite.
+
 ### Commands
 See a more in depth explanation of each function in the associated docstring
 

--- a/cb.py
+++ b/cb.py
@@ -184,6 +184,22 @@ class CoopBoop:
         return mapping
 
 
+    def save_config(self):
+        """ Save the current state of the bot to the config file
+        """
+        config = {}
+
+        config['owner'] = self.owner 
+        config['perms'] = self.perms
+        config['header'] = self.header or "None"
+        config['dnd_msg'] = self.dnd_msg or "None"
+        config['dnd_pic'] = self.dnd_pic or "None"
+
+        self.bot_log("Saving config")
+        with open("test.json", "w") as config_file:
+            json.dump(config, config_file, indent=4)
+            self.bot_log("Config saved")
+
     @perm
     async def set_header(self, event):
         """ Set the header of the bot at self.header to all text after ";hdr "
@@ -208,17 +224,7 @@ class CoopBoop:
 
         Ex: ;sid
         """
-        # Save configuration
-        config = {}
-        config['owner'] = self.owner 
-        config['perms'] = self.perms
-        config['header'] = self.header or "None"
-        config['dnd_msg'] = self.dnd_msg or "None"
-        config['dnd_pic'] = self.dnd_pic or "None"
-        self.bot_log("Saving config")
-        with open("test.json", "w") as config_file:
-            json.dump(config, config_file, indent=4)
-
+        self.save_config()
         self.bot_log("Shutting down")
         self.bot_log_file.close()
         await event.client.disconnect()

--- a/cb.py
+++ b/cb.py
@@ -53,9 +53,9 @@ class CoopBoop:
         self.dnd_tracker = {}
 
         # Start
-        api_id = config['API_id']
-        api_hash = config['API_hash']
-        owner_name = config['owner_name']
+        self.api_id = config['API_id']
+        self.api_hash = config['API_hash']
+        self.owner_name = config['owner_name']
         self.client = TelegramClient(owner_name, api_id, api_hash)
         print("Bot started")
 
@@ -196,6 +196,9 @@ class CoopBoop:
         config['header'] = self.header or "None"
         config['dnd_msg'] = self.dnd_msg or "None"
         config['dnd_pic'] = self.dnd_pic or "None"
+        config['API_id'] = self.api_id 
+        config['API_hash'] = self.api_hash
+        config['owner_name'] = self.owner_name
 
         self.bot_log(f"Saving config to {path}")
         with open(path, "w") as config_file:

--- a/cb.py
+++ b/cb.py
@@ -191,7 +191,7 @@ class CoopBoop:
         """
         config = {}
 
-        config['owner'] = self.owner 
+        config['owner'] = self.owner
         config['perms'] = self.perms
         config['header'] = self.header or "None"
         config['dnd_msg'] = self.dnd_msg or "None"

--- a/cb.py
+++ b/cb.py
@@ -217,7 +217,7 @@ class CoopBoop:
         config['dnd_pic'] = self.dnd_pic or "None"
         self.bot_log("Saving config")
         with open("test.json", "w") as config_file:
-            json.dump(config, config_file)
+            json.dump(config, config_file, indent=4)
 
         self.bot_log("Shutting down")
         self.bot_log_file.close()

--- a/cb.py
+++ b/cb.py
@@ -186,6 +186,8 @@ class CoopBoop:
 
     def save_config(self, path="config.json"):
         """ Save the current state of the bot to the config file
+        -Take extra care as to where you call this.
+        -Don't hand it off to user input EVER: arbitrary file overwrite
         """
         config = {}
 
@@ -196,7 +198,7 @@ class CoopBoop:
         config['dnd_pic'] = self.dnd_pic or "None"
 
         self.bot_log("Saving config")
-        with open("test.json", "w") as config_file:
+        with open(path, "w") as config_file:
             json.dump(config, config_file, indent=4)
             self.bot_log("Config saved")
 

--- a/cb.py
+++ b/cb.py
@@ -210,26 +210,11 @@ class CoopBoop:
         """
         # Permissions
         config = {}
-        self.owner = config['owner']
-        self.perms = config['perms']
-        for command in self.perms:
-            if self.perms[command]['whitelist'] == [ "OWNER" ]:
-                self.perms[command]['whitelist'] = [ self.owner ]
-
-        # Default message reply header
-        self.header = config['header']
-
-        # Set file to log bot activity to
-        self.bot_log_file = open("./bot_log.txt", 'a')
-
-        # File download location
-        self.file_download_path = "./tmp/"
-
-        # Set do not disturb to off by default
-        self.dnd = False
-        self.dnd_msg = config['dnd_msg'] if config['dnd_msg'] != "None" else None
-        self.dnd_pic = config['dnd_pic'] if config['dnd_pic'] != "None" else None
-        self.dnd_tracker = {}
+        config['owner'] = self.owner 
+        config['perms'] = self.perms
+        config['header'] = self.header or "None"
+        config['dnd_msg'] = self.dnd_msg or "None"
+        config['dnd_pic'] = self.dnd_pic or "None"
 
         # Load from config file
         with open("config.json", "r") as config_file:

--- a/cb.py
+++ b/cb.py
@@ -217,7 +217,7 @@ class CoopBoop:
         config['dnd_pic'] = self.dnd_pic or "None"
         self.bot_log("Saving config")
         with open("test.json", "w") as config_file:
-            json.load(config, config_file)
+            json.dump(config, config_file)
 
         self.bot_log("Shutting down")
         self.bot_log_file.close()

--- a/cb.py
+++ b/cb.py
@@ -184,7 +184,7 @@ class CoopBoop:
         return mapping
 
 
-    def save_config(self):
+    def save_config(self, path="config.json"):
         """ Save the current state of the bot to the config file
         """
         config = {}

--- a/cb.py
+++ b/cb.py
@@ -53,8 +53,8 @@ class CoopBoop:
         self.dnd_tracker = {}
 
         # Start
-        self.api_id = config['API_id']
-        self.api_hash = config['API_hash']
+        self.api_id = config['api_id']
+        self.api_hash = config['api_hash']
         self.owner_name = config['owner_name']
         self.client = TelegramClient(owner_name, api_id, api_hash)
         print("Bot started")
@@ -196,8 +196,8 @@ class CoopBoop:
         config['header'] = self.header or "None"
         config['dnd_msg'] = self.dnd_msg or "None"
         config['dnd_pic'] = self.dnd_pic or "None"
-        config['API_id'] = self.api_id 
-        config['API_hash'] = self.api_hash
+        config['api_id'] = self.api_id 
+        config['api_hash'] = self.api_hash
         config['owner_name'] = self.owner_name
 
         self.bot_log(f"Saving config to {path}")

--- a/cb.py
+++ b/cb.py
@@ -56,7 +56,7 @@ class CoopBoop:
         self.api_id = config['api_id']
         self.api_hash = config['api_hash']
         self.owner_name = config['owner_name']
-        self.client = TelegramClient(owner_name, api_id, api_hash)
+        self.client = TelegramClient(self.owner_name, self.api_id, self.api_hash)
         print("Bot started")
 
 

--- a/cb.py
+++ b/cb.py
@@ -208,17 +208,17 @@ class CoopBoop:
 
         Ex: ;sid
         """
-        # Permissions
+        # Save configuration
         config = {}
         config['owner'] = self.owner 
         config['perms'] = self.perms
         config['header'] = self.header or "None"
         config['dnd_msg'] = self.dnd_msg or "None"
         config['dnd_pic'] = self.dnd_pic or "None"
+        self.bot_log("Saving config")
+        with open("test.json", "w") as config_file:
+            json.load(config, config_file)
 
-        # Load from config file
-        with open("config.json", "r") as config_file:
-            config = json.load(config_file)
         self.bot_log("Shutting down")
         self.bot_log_file.close()
         await event.client.disconnect()

--- a/cb.py
+++ b/cb.py
@@ -197,10 +197,11 @@ class CoopBoop:
         config['dnd_msg'] = self.dnd_msg or "None"
         config['dnd_pic'] = self.dnd_pic or "None"
 
-        self.bot_log("Saving config")
+        self.bot_log(f"Saving config to {path}")
         with open(path, "w") as config_file:
             json.dump(config, config_file, indent=4)
-            self.bot_log("Config saved")
+            self.bot_log(f"Config saved to {path}")
+
 
     @perm
     async def set_header(self, event):

--- a/cb.py
+++ b/cb.py
@@ -208,6 +208,32 @@ class CoopBoop:
 
         Ex: ;sid
         """
+        # Permissions
+        config = {}
+        self.owner = config['owner']
+        self.perms = config['perms']
+        for command in self.perms:
+            if self.perms[command]['whitelist'] == [ "OWNER" ]:
+                self.perms[command]['whitelist'] = [ self.owner ]
+
+        # Default message reply header
+        self.header = config['header']
+
+        # Set file to log bot activity to
+        self.bot_log_file = open("./bot_log.txt", 'a')
+
+        # File download location
+        self.file_download_path = "./tmp/"
+
+        # Set do not disturb to off by default
+        self.dnd = False
+        self.dnd_msg = config['dnd_msg'] if config['dnd_msg'] != "None" else None
+        self.dnd_pic = config['dnd_pic'] if config['dnd_pic'] != "None" else None
+        self.dnd_tracker = {}
+
+        # Load from config file
+        with open("config.json", "r") as config_file:
+            config = json.load(config_file)
         self.bot_log("Shutting down")
         self.bot_log_file.close()
         await event.client.disconnect()

--- a/config.json
+++ b/config.json
@@ -1,8 +1,8 @@
 {
   "owner_name": 0,
   "owner": 0,
-  "API_id": 0,
-  "API_hash": 0,
+  "api_id": 0,
+  "api_hash": 0,
   "perms": {
     "set_header": {
       "whitelist": [ "OWNER" ],


### PR DESCRIPTION
This is a feature update which acts as a prerequisite to adding the features for whitelist & blacklist commands (who wants to type in the list of admins, spammers, & trolls every time they restart the bot?)

-Add function for saving current configuration of bot
-Save config of bot in shutdown_switch/;sid

New potential security vulnerability: save_config takes path to save json file. Never allow user input to determine said path, possible arbitrary file overwrite vulnerability if function not handled correctly. Added comment about this.